### PR TITLE
tty-player: Wrap and show the poster when the 'video' ends

### DIFF
--- a/tty-player.js
+++ b/tty-player.js
@@ -697,6 +697,11 @@ ISP.render = function() {
 			this.fireSimpleEvent("timeupdate");
 			this.ttyPlayer["pause"]();
 			this.fireSimpleEvent("ended");
+
+			if (this.ttyPlayer["poster"] != "") {
+				this.ttyPlayer["currentTime"] = 0;
+				this.showPoster = true;
+			}
 		}
 	} else {
 		// Do we need to fire a timeupdate event? We should do them every 66–350ms; Firefox does 250 for video, but because the average length is going to be shorter and because I can, I’m going for 100ms.


### PR DESCRIPTION
This way, it feels a bit more natural, rather than just hard-stopping at the end.